### PR TITLE
Galvo SPI Mode to 1

### DIFF
--- a/software/Arduino/firmware/firmware.ino
+++ b/software/Arduino/firmware/firmware.ino
@@ -47,7 +47,7 @@ static const std::map< char , Spi_target > spi_targets = {
   {'4', Spi_target( 11 , 12 , 13 , 10 , SPI_BPS , 2 ) },    // SPI4-AD5766, CLK idle HIGH, Sample on FALL, MSb first - https://www.analog.com/media/en/technical-documentation/data-sheets/ad5766-5767.pdf
   {'5', Spi_target( 17 , 16 , 15 , 14 , SPI_BPS , 2 ) },    // SPI5-AD5142, CLK idle HIGH, Sample on FALL, MSb first - https://www.analog.com/media/en/technical-documentation/data-sheets/AD5122_5142.pdf
   
-  {'A', Spi_target(  4 ,  6 ,  2 , 37 , SPI_BPS , 0 ) },        // On the aux header on the right side of the PCB - For galvo. 
+  {'A', Spi_target(  4 ,  6 ,  2 , 37 , SPI_BPS , 1 ) },        // On the aux header on the right side of the PCB - For galvo. 
   
 };
 


### PR DESCRIPTION
The galvo SPI interface uses mode 1 and not 0 now that I have tested it out.